### PR TITLE
Enhanced Mushrooms compat

### DIFF
--- a/src/main/java/com/minecraftabnormals/environmental/common/world/EnvironmentalBiomeFeatures.java
+++ b/src/main/java/com/minecraftabnormals/environmental/common/world/EnvironmentalBiomeFeatures.java
@@ -8,8 +8,10 @@ import com.minecraftabnormals.environmental.common.world.gen.util.WisteriaColor;
 import com.minecraftabnormals.environmental.core.EnvironmentalConfig;
 import com.minecraftabnormals.environmental.core.registry.EnvironmentalFeatures;
 
+import com.minecraftabnormals.environmental.integration.enhanced_mushrooms.EnhancedMushrooms;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
+import net.minecraft.block.HugeMushroomBlock;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.DefaultBiomeFeatures;
 import net.minecraft.world.gen.GenerationStage;
@@ -18,20 +20,7 @@ import net.minecraft.world.gen.Heightmap;
 import net.minecraft.world.gen.blockplacer.DoublePlantBlockPlacer;
 import net.minecraft.world.gen.blockplacer.SimpleBlockPlacer;
 import net.minecraft.world.gen.blockstateprovider.SimpleBlockStateProvider;
-import net.minecraft.world.gen.feature.BaseTreeFeatureConfig;
-import net.minecraft.world.gen.feature.BlockClusterFeatureConfig;
-import net.minecraft.world.gen.feature.BlockStateFeatureConfig;
-import net.minecraft.world.gen.feature.ConfiguredFeature;
-import net.minecraft.world.gen.feature.DecoratedFeatureConfig;
-import net.minecraft.world.gen.feature.Feature;
-import net.minecraft.world.gen.feature.IFeatureConfig;
-import net.minecraft.world.gen.feature.MultipleRandomFeatureConfig;
-import net.minecraft.world.gen.feature.MultipleWithChanceRandomFeatureConfig;
-import net.minecraft.world.gen.feature.NoFeatureConfig;
-import net.minecraft.world.gen.feature.ProbabilityConfig;
-import net.minecraft.world.gen.feature.SeaGrassConfig;
-import net.minecraft.world.gen.feature.SphereReplaceConfig;
-import net.minecraft.world.gen.feature.TwoFeatureChoiceConfig;
+import net.minecraft.world.gen.feature.*;
 import net.minecraft.world.gen.placement.AtSurfaceWithExtraConfig;
 import net.minecraft.world.gen.placement.ChanceConfig;
 import net.minecraft.world.gen.placement.CountRangeConfig;
@@ -44,7 +33,23 @@ import net.minecraft.world.gen.placement.TopSolidWithNoiseConfig;
 public class EnvironmentalBiomeFeatures {
     public static void addMushrooms(Biome biome) {
         if (EnvironmentalConfig.COMMON.generateGiantMushroomsInSwamps.get()) {
-            biome.addFeature(GenerationStage.Decoration.VEGETAL_DECORATION, Feature.RANDOM_BOOLEAN_SELECTOR.withConfiguration(new TwoFeatureChoiceConfig(Feature.HUGE_RED_MUSHROOM.withConfiguration(DefaultBiomeFeatures.BIG_RED_MUSHROOM), Feature.HUGE_BROWN_MUSHROOM.withConfiguration(DefaultBiomeFeatures.BIG_BROWN_MUSHROOM))).withPlacement(Placement.COUNT_HEIGHTMAP.configure(new FrequencyConfig(1))));
+            BlockState RED_MUSHROOM_CAP = Blocks.RED_MUSHROOM_BLOCK.getDefaultState().with(HugeMushroomBlock.DOWN, Boolean.valueOf(false));
+            BlockState BROWN_MUSHROOM_CAP = Blocks.BROWN_MUSHROOM_BLOCK.getDefaultState().with(HugeMushroomBlock.UP, Boolean.valueOf(true)).with(HugeMushroomBlock.DOWN, Boolean.valueOf(false));
+            if (EnhancedMushrooms.isInstalled()) {
+                BigMushroomFeatureConfig RED_MUSHROOM_CONFIG = (
+                        new BigMushroomFeatureConfig(
+                                new SimpleBlockStateProvider(RED_MUSHROOM_CAP),
+                                new SimpleBlockStateProvider(EnhancedMushrooms.RED_MUSHROOM_STEM.getDefaultState()),
+                                2));
+                BigMushroomFeatureConfig BROWN_MUSHROOM_CONFIG = (
+                        new BigMushroomFeatureConfig(
+                                new SimpleBlockStateProvider(BROWN_MUSHROOM_CAP),
+                                new SimpleBlockStateProvider(EnhancedMushrooms.BROWN_MUSHROOM_STEM.getDefaultState()),
+                                3));
+                biome.addFeature(GenerationStage.Decoration.VEGETAL_DECORATION, Feature.RANDOM_BOOLEAN_SELECTOR.withConfiguration(new TwoFeatureChoiceConfig(Feature.HUGE_RED_MUSHROOM.withConfiguration(RED_MUSHROOM_CONFIG), Feature.HUGE_BROWN_MUSHROOM.withConfiguration(BROWN_MUSHROOM_CONFIG))).withPlacement(Placement.COUNT_HEIGHTMAP.configure(new FrequencyConfig(1))));
+            } else {
+                biome.addFeature(GenerationStage.Decoration.VEGETAL_DECORATION, Feature.RANDOM_BOOLEAN_SELECTOR.withConfiguration(new TwoFeatureChoiceConfig(Feature.HUGE_RED_MUSHROOM.withConfiguration(DefaultBiomeFeatures.BIG_RED_MUSHROOM), Feature.HUGE_BROWN_MUSHROOM.withConfiguration(DefaultBiomeFeatures.BIG_BROWN_MUSHROOM))).withPlacement(Placement.COUNT_HEIGHTMAP.configure(new FrequencyConfig(1))));
+            }
         }
         biome.addFeature(GenerationStage.Decoration.VEGETAL_DECORATION, Feature.RANDOM_PATCH.withConfiguration(DefaultBiomeFeatures.BROWN_MUSHROOM_CONFIG).withPlacement(Placement.COUNT_CHANCE_HEIGHTMAP.configure(new HeightWithChanceConfig(1, 0.25F))));
         biome.addFeature(GenerationStage.Decoration.VEGETAL_DECORATION, Feature.RANDOM_PATCH.withConfiguration(DefaultBiomeFeatures.RED_MUSHROOM_CONFIG).withPlacement(Placement.COUNT_CHANCE_HEIGHTMAP_DOUBLE.configure(new HeightWithChanceConfig(1, 0.125F))));

--- a/src/main/java/com/minecraftabnormals/environmental/common/world/EnvironmentalBiomeFeatures.java
+++ b/src/main/java/com/minecraftabnormals/environmental/common/world/EnvironmentalBiomeFeatures.java
@@ -56,7 +56,17 @@ public class EnvironmentalBiomeFeatures {
     }
 
     public static void addMarshMushrooms(Biome biome) {
-        biome.addFeature(GenerationStage.Decoration.VEGETAL_DECORATION, Feature.HUGE_BROWN_MUSHROOM.withConfiguration(DefaultBiomeFeatures.BIG_BROWN_MUSHROOM).withPlacement(Placement.COUNT_EXTRA_HEIGHTMAP.configure(new AtSurfaceWithExtraConfig(0, 0.32F, 1))));
+        BlockState BROWN_MUSHROOM_CAP = Blocks.BROWN_MUSHROOM_BLOCK.getDefaultState().with(HugeMushroomBlock.UP, Boolean.valueOf(true)).with(HugeMushroomBlock.DOWN, Boolean.valueOf(false));
+        if (EnhancedMushrooms.isInstalled()) {
+            BigMushroomFeatureConfig BROWN_MUSHROOM_CONFIG = (
+                    new BigMushroomFeatureConfig(
+                            new SimpleBlockStateProvider(BROWN_MUSHROOM_CAP),
+                            new SimpleBlockStateProvider(EnhancedMushrooms.BROWN_MUSHROOM_STEM.getDefaultState()),
+                            3));
+            biome.addFeature(GenerationStage.Decoration.VEGETAL_DECORATION, Feature.HUGE_BROWN_MUSHROOM.withConfiguration(BROWN_MUSHROOM_CONFIG).withPlacement(Placement.COUNT_EXTRA_HEIGHTMAP.configure(new AtSurfaceWithExtraConfig(0, 0.32F, 1))));
+        } else {
+            biome.addFeature(GenerationStage.Decoration.VEGETAL_DECORATION, Feature.HUGE_BROWN_MUSHROOM.withConfiguration(DefaultBiomeFeatures.BIG_BROWN_MUSHROOM).withPlacement(Placement.COUNT_EXTRA_HEIGHTMAP.configure(new AtSurfaceWithExtraConfig(0, 0.32F, 1))));
+        }
     }
 
     public static void addMarshVegetation(Biome biome) {

--- a/src/main/java/com/minecraftabnormals/environmental/integration/enhanced_mushrooms/EnhancedMushrooms.java
+++ b/src/main/java/com/minecraftabnormals/environmental/integration/enhanced_mushrooms/EnhancedMushrooms.java
@@ -1,0 +1,17 @@
+package com.minecraftabnormals.environmental.integration.enhanced_mushrooms;
+
+import net.minecraft.block.Block;
+import net.minecraftforge.fml.ModList;
+import net.minecraftforge.registries.ObjectHolder;
+
+public class EnhancedMushrooms {
+    @ObjectHolder("enhanced_mushrooms:red_mushroom_stem")
+    public static final Block RED_MUSHROOM_STEM = null;
+
+    @ObjectHolder("enhanced_mushrooms:brown_mushroom_stem")
+    public static final Block BROWN_MUSHROOM_STEM = null;
+
+    public static boolean isInstalled() {
+        return ModList.get() != null && ModList.get().getModContainerById("enhanced_mushrooms").isPresent();
+    }
+}


### PR DESCRIPTION
Adds integration with Enhanced Mushrooms' mushroom stems. Due to Environmental's mushrooms in swamps feature adding features in a DeferredWorkQueue it depends on the random loading order whether they're replaced by EM mushrooms or not. This fixes that by using ObjectHolders to just stick the stems in there on Environmental's end if EM is installed. I've tested it with the latest GitHub build of EM and it seems to be working.

I think this _should_ work with the latest CF build of EM but if not, it should definitely work with the latest GitHub build, which will be uploaded to CurseForge soon™